### PR TITLE
Correct typo

### DIFF
--- a/src/plugsig_h.rpgle
+++ b/src/plugsig_h.rpgle
@@ -189,7 +189,7 @@
       * Qp0sDisableSignals(): Disable signals
       *++++++++++++++++++++++++++++++++++++++++++++++++++++++++
      D Qp0sDisableSignals...
-     D                 PR            10I 0 extproc('Qp0sEnableSignals')
+     D                 PR            10I 0 extproc('Qp0sDisableSignals')
 
       *++++++++++++++++++++++++++++++++++++++++++++++++++++++++
       * default signal handlers


### PR DESCRIPTION
"Enable" should have been "Disable" per the surrounding code and comment.
Note: this code might not be used.