### PR TITLE
Update ilePGM() and ileSRV() to count parameters backwards so they don't leave off subsequent parameters after an omitted parameter

### DIFF
--- a/src/plugile.rpgle
+++ b/src/plugile.rpgle
@@ -4427,6 +4427,41 @@
      D anyProc         s               *   inz(*NULL)
      D myDS            ds                  likeds(AnyDS) based(anyProc)
      D procPtr         S               *   ProcPtr
+
+     D proc32_int32    Pr            10i 0 ExtProc(procPtr)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+     D  argPtr                         *   value options(*nopass)
+
      D pMyProc0        Pr         65000A   ExtProc(procPtr)
      D pMyProc1        Pr         65000A   ExtProc(procPtr)
      D  pargv1                         *   value
@@ -5020,6 +5055,9 @@
          argc -= 1;
        enddo;
 
+       // set return value pointer addresses
+       pCopy2 = %addr(myBuf);
+
        if piReturn <> *NULL;
          pCopy = piReturn;
          myCopy.intx = -1;
@@ -5030,7 +5068,206 @@
        procPtr = myDS.AnyProc;
 
        select;
-       when argc = 0;
+       when (argc = 0 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32();
+       when (argc = 1 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1));
+       when (argc = 2 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2));
+       when (argc = 3 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3));
+       when (argc = 4 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4));
+       when (argc = 5 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5) );
+       when (argc = 6 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6) );
+       when (argc = 7 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7) );
+       when (argc = 8 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8) );
+       when (argc = 9 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9) );
+       when (argc = 10 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10) );
+       when (argc = 11 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11) );
+       when (argc = 12 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12) );
+       when (argc = 13 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13)
+                                    );
+       when (argc = 14 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14)
+                                    );
+       when (argc = 15 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14): argv(15)
+                                    );
+       when (argc = 16 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14): argv(15): argv(16)
+                                    );
+       when (argc = 17 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14): argv(15): argv(16):
+                                     argv(17)
+                                    );
+       when (argc = 18 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14): argv(15): argv(16):
+                                     argv(17): argv(18)
+                                    );
+       when (argc = 19 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14): argv(15): argv(16):
+                                     argv(17): argv(18): argv(19)
+                                    );
+       when (argc = 20 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14): argv(15): argv(16):
+                                     argv(17): argv(18): argv(19): argv(20)
+                                    );
+       when (argc = 21 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14): argv(15): argv(16):
+                                     argv(17): argv(18): argv(19): argv(20):
+                                     argv(21)
+                                    );
+       when (argc = 22 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14): argv(15): argv(16):
+                                     argv(17): argv(18): argv(19): argv(20):
+                                     argv(21): argv(22)
+                                    );
+       when (argc = 23 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14): argv(15): argv(16):
+                                     argv(17): argv(18): argv(19): argv(20):
+                                     argv(21): argv(22): argv(23)
+                                    );
+       when (argc = 24 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14): argv(15): argv(16):
+                                     argv(17): argv(18): argv(19): argv(20):
+                                     argv(21): argv(22): argv(23): argv(24)
+                                    );
+       when (argc = 25 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14): argv(15): argv(16):
+                                     argv(17): argv(18): argv(19): argv(20):
+                                     argv(21): argv(22): argv(23): argv(24):
+                                     argv(25)
+                                    );
+       when (argc = 26 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14): argv(15): argv(16):
+                                     argv(17): argv(18): argv(19): argv(20):
+                                     argv(21): argv(22): argv(23): argv(24):
+                                     argv(25): argv(26)
+                                    );
+       when (argc = 27 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14): argv(15): argv(16):
+                                     argv(17): argv(18): argv(19): argv(20):
+                                     argv(21): argv(22): argv(23): argv(24):
+                                     argv(25): argv(26): argv(27)
+                                    );
+       when (argc = 28 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14): argv(15): argv(16):
+                                     argv(17): argv(18): argv(19): argv(20):
+                                     argv(21): argv(22): argv(23): argv(24):
+                                     argv(25): argv(26): argv(27): argv(28)
+                                    );
+       when (argc = 29 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14): argv(15): argv(16):
+                                     argv(17): argv(18): argv(19): argv(20):
+                                     argv(21): argv(22): argv(23): argv(24):
+                                     argv(25): argv(26): argv(27): argv(28):
+                                     argv(29)
+                                    );
+       when (argc = 30 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14): argv(15): argv(16):
+                                     argv(17): argv(18): argv(19): argv(20):
+                                     argv(21): argv(22): argv(23): argv(24):
+                                     argv(25): argv(26): argv(27): argv(28):
+                                     argv(29): argv(30)
+                                    );
+       when (argc = 31 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14): argv(15): argv(16):
+                                     argv(17): argv(18): argv(19): argv(20):
+                                     argv(21): argv(22): argv(23): argv(24):
+                                     argv(25): argv(26): argv(27): argv(28):
+                                     argv(29): argv(30): argv(31)
+                                    );
+       when (argc = 32 and retSize = RESULT_INT32);
+         myCopy2.intx = proc32_int32(argv(1): argv(2): argv(3): argv(4):
+                                     argv(5): argv(6): argv(7): argv(8):
+                                     argv(9): argv(10): argv(11): argv(12):
+                                     argv(13): argv(14): argv(15): argv(16):
+                                     argv(17): argv(18): argv(19): argv(20):
+                                     argv(21): argv(22): argv(23): argv(24):
+                                     argv(25): argv(26): argv(27): argv(28):
+                                     argv(29): argv(30): argv(31): argv(32)
+                                    );
+
+       when (argc = 0);
          myBuf = pMyProc0();
        when argc = 1;
          myBuf = pMyProc1(argv(1));
@@ -5218,8 +5455,6 @@
        // from PASE ILE BASE to the return area
        // xml is expecting as output
        if piReturn <> *NULL;
-         pCopy2 = %addr(myBuf);
-         pCopy = piReturn;
          select;
          when retSize = RESULT_INT8;
            myCopy.chrx =  myCopy2.chrx;

--- a/src/plugile.rpgle
+++ b/src/plugile.rpgle
@@ -4408,8 +4408,8 @@
      D pCopy           s               *
      D myCopy          ds                  likeds(over_t) based(pCopy)
      D myBuf           S          65000A   inz(*BLANKS)
-     D myPtr           S               *   inz(*NULL)
-     D myCopy2         ds                  likeds(over_t) based(pCopy)
+     D pCopy2          S               *   inz(*NULL)
+     D myCopy2         ds                  likeds(over_t) based(pCopy2)
       * debug
      D tBenArgSz       s             10i 0 inz(0)
      D tBenArgP        S               *   inz(*NULL)
@@ -5013,11 +5013,7 @@
 
        // find the last parameter given - allows *OMIT parameters in the middle
        argc = %elem(argv);
-       dow 1 = 1;
-         if argc = 0;
-           leave;
-         endif;
-
+       dow argc > 0;
          // make sure we only look at pointers within the
          // memory space allocated and in use for them
          pArgvCurrEnd = %addr(argv(argc)) + %size(argv(argc)) - 1;
@@ -5226,7 +5222,7 @@
        // from PASE ILE BASE to the return area
        // xml is expecting as output
        if piReturn <> *NULL;
-         myPtr = %addr(myBuf);
+         pCopy2 = %addr(myBuf);
          pCopy = piReturn;
          select;
          when retSize = RESULT_INT8;
@@ -5249,7 +5245,7 @@
            myCopy.doublex = myCopy2.doublex;
          other;
            if retSize > 0;
-             cpybytes(piReturn:myPtr:retSize);
+             cpybytes(piReturn:pCopy2:retSize);
            endif;
          endsl;
        endif;

--- a/src/plugile.rpgle
+++ b/src/plugile.rpgle
@@ -4349,11 +4349,7 @@
 
        // find the last parameter given - allows *OMIT parameters in the middle
        argc = %elem(argv);
-       dow 1 = 1;
-         if argc = 0;
-           leave;
-         endif;
-
+       dow argc > 0;
          // make sure we only look at pointers within the
          // memory space allocated and in use for them
          pArgvCurrEnd = %addr(argv(argc)) + %size(argv(argc)) - 1;

--- a/src/plugile.rpgle
+++ b/src/plugile.rpgle
@@ -4326,7 +4326,7 @@
      D argc            S             10I 0 inz(0)
      d argv            s               *   dim(256) based(pargv)
 
-     d pArgvCurr       s               *
+     d pArgvCurrEnd    s               *
      d pArgvEnd        s               *
 
       /free
@@ -4356,8 +4356,8 @@
 
          // make sure we only look at pointers within the
          // memory space allocated and in use for them
-         pArgvCurr = %addr(argv(argc));
-         if pArgvCurr < pArgvEnd and argv(argc) <> *NULL;
+         pArgvCurrEnd = %addr(argv(argc)) + %size(argv(argc)) - 1;
+         if pArgvCurrEnd <= pArgvEnd and argv(argc) <> *NULL;
            leave;
          endif;
 
@@ -4422,7 +4422,7 @@
      D argc            S             10I 0 inz(0)
      d argv            s               *   dim(256) based(pargv)
 
-     d pArgvCurr       s               *
+     d pArgvCurrEnd    s               *
      d pArgvEnd        s               *
 
      d div16           s             10i 0 inz(16)
@@ -5020,8 +5020,8 @@
 
          // make sure we only look at pointers within the
          // memory space allocated and in use for them
-         pArgvCurr = %addr(argv(argc));
-         if pArgvCurr < pArgvEnd and argv(argc) <> *NULL;
+         pArgvCurrEnd = %addr(argv(argc)) + %size(argv(argc)) - 1;
+         if pArgvCurrEnd <= pArgvEnd and argv(argc) <> *NULL;
            leave;
          endif;
 


### PR DESCRIPTION
Closes #63 

The current logic starting at lines https://github.com/IBM/xmlservice/blob/master/src/plugile.rpgle#L4342 and https://github.com/IBM/xmlservice/blob/master/src/plugile.rpgle#L4985 doesn't work correctly because it assumes once you hit a parameter with a null pointer there are no other valid parameters following that. Unfortunately if you have a parameter that allows *OMIT and then specify a later parameter then it won't pass that later parameter.

My changes walk backwards through the parameter pointer array instead, finding the last valid parameter. I also put code in place to ensure it doesn't evaluate memory that's not technically in use (using sArgvSz) although in theory those unused pointers are already initialized to null.